### PR TITLE
Fix API

### DIFF
--- a/isimip_data/metadata/filters.py
+++ b/isimip_data/metadata/filters.py
@@ -177,6 +177,7 @@ class TreeFilterBackend(BaseFilterBackend):
         if tree_list:
             q = Q()
             for tree in tree_list:
+                tree = tree.rstrip('/') + '/'
                 if queryset.model == File:
                     q |= Q(dataset__tree_path__startswith=tree)
                     if getattr(view, 'filter_resolve_links', True):

--- a/isimip_data/metadata/filters.py
+++ b/isimip_data/metadata/filters.py
@@ -2,7 +2,7 @@ import logging
 
 from django.contrib.postgres.search import SearchQuery
 from django.core.exceptions import FieldError, ValidationError
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 
 from rest_framework.filters import BaseFilterBackend
 
@@ -35,7 +35,7 @@ class DatasetFilterBackend(BaseFilterBackend):
             return queryset
 
         dataset_ids = request.GET.getlist('dataset')
-        print(request.GET)
+
         if dataset_ids:
             queryset = queryset.filter(dataset_id__in=dataset_ids)
 
@@ -65,7 +65,12 @@ class PathFilterBackend(BaseFilterBackend):
         if path_list:
             q = Q()
             for path in path_list:
-                q |= Q(path__startswith=path) | Q(links__path__startswith=path)
+                q |= Q(path__startswith=path)
+                if getattr(view, 'filter_resolve_links', True):
+                    q |= Exists(
+                        queryset.model.objects.filter(target_id=OuterRef('pk'), path__startswith=path)
+                    )
+
             queryset = queryset.filter(q)
 
         return queryset
@@ -94,9 +99,19 @@ class SearchFilterBackend(BaseFilterBackend):
 
             # last, perform a full text search on the search_vector field
             if queryset.model == File:
-                queryset = queryset.filter(dataset__search__vector=search_query)
+                q = Q(dataset__search__vector=search_query)
+                if getattr(view, 'filter_resolve_links', True):
+                    q |= Exists(
+                        queryset.model.objects.filter(target_id=OuterRef('pk'), dataset__search__vector=search_query)
+                    )
             else:
-                queryset = queryset.filter(search__vector=search_query)
+                q = Q(search__vector=search_query)
+                if getattr(view, 'filter_resolve_links', True):
+                    q |= Exists(
+                        queryset.model.objects.filter(target_id=OuterRef('pk'), search__vector=search_query)
+                    )
+
+            queryset = queryset.filter(q)
 
         return queryset
 
@@ -132,16 +147,21 @@ class IdentifierFilterBackend(BaseFilterBackend):
         if view.detail:
             return queryset
 
-        # see https://docs.djangoproject.com/en/2.2/ref/contrib/postgres/fields/#std:fieldlookup-hstorefield.contains
-        # and https://docs.djangoproject.com/en/2.2/ref/contrib/postgres/fields/#containment-and-key-operations
-        # for optimal jsonb lookups: queryset.filter(field={'foo': 'bar', 'egg': 'spam'})
         for identifier in Identifier.objects.using('metadata').identifiers():
-            if identifier != getattr(view, 'identifier_filter_exclude', None):
+            if identifier != getattr(view, 'filter_exclude_identifier', None):
                 q = Q()
                 for value in request.GET.getlist(identifier):
                     if value:
                         q |= Q(specifiers__contains={identifier: value})
-                        q |= Q(links__specifiers__contains={identifier: value})
+
+                        if getattr(view, 'filter_resolve_links', True):
+                            q |= Exists(
+                                queryset.model.objects.filter(
+                                    target_id=OuterRef('pk'),
+                                    specifiers__contains={identifier: value}
+                                )
+                            )
+
                 queryset = queryset.filter(q)
 
         return queryset
@@ -158,9 +178,17 @@ class TreeFilterBackend(BaseFilterBackend):
             q = Q()
             for tree in tree_list:
                 if queryset.model == File:
-                    q |= Q(dataset__tree_path__startswith=tree) | Q(dataset__links__tree_path__startswith=tree)
+                    q |= Q(dataset__tree_path__startswith=tree)
+                    if getattr(view, 'filter_resolve_links', True):
+                        q |= Exists(
+                            queryset.model.objects.filter(target_id=OuterRef('pk'), dataset__tree_path__startswith=tree)
+                        )
                 else:
-                    q |= Q(tree_path__startswith=tree) | Q(links__tree_path__startswith=tree)
+                    q |= Q(tree_path__startswith=tree)
+                    if getattr(view, 'filter_resolve_links', True):
+                        q |= Exists(
+                            queryset.model.objects.filter(target_id=OuterRef('pk'), tree_path__startswith=tree)
+                        )
 
             queryset = queryset.filter(q)
 

--- a/isimip_data/metadata/filters.py
+++ b/isimip_data/metadata/filters.py
@@ -1,8 +1,8 @@
 import logging
 
 from django.contrib.postgres.search import SearchQuery
-from django.core.exceptions import FieldError, ValidationError
-from django.db.models import Exists, OuterRef, Q
+from django.core.exceptions import ValidationError
+from django.db.models import Q
 
 from rest_framework.filters import BaseFilterBackend
 
@@ -65,11 +65,13 @@ class PathFilterBackend(BaseFilterBackend):
         if path_list:
             q = Q()
             for path in path_list:
-                q |= Q(path__startswith=path)
+                filter_kwargs = {'path__startswith': path}
+
                 if getattr(view, 'filter_resolve_links', True):
-                    q |= Exists(
-                        queryset.model.objects.filter(target_id=OuterRef('pk'), path__startswith=path)
-                    )
+                    subquery = queryset.model.objects.filter(**filter_kwargs).values('root_id').order_by()
+                    q |= Q(root_id__in=subquery)
+                else:
+                    q |= Q(**filter_kwargs)
 
             queryset = queryset.filter(q)
 
@@ -99,19 +101,15 @@ class SearchFilterBackend(BaseFilterBackend):
 
             # last, perform a full text search on the search_vector field
             if queryset.model == File:
-                q = Q(dataset__search__vector=search_query)
-                if getattr(view, 'filter_resolve_links', True):
-                    q |= Exists(
-                        queryset.model.objects.filter(target_id=OuterRef('pk'), dataset__search__vector=search_query)
-                    )
+                filter_kwargs = {'dataset__search__vector': search_query}
             else:
-                q = Q(search__vector=search_query)
-                if getattr(view, 'filter_resolve_links', True):
-                    q |= Exists(
-                        queryset.model.objects.filter(target_id=OuterRef('pk'), search__vector=search_query)
-                    )
+                filter_kwargs = {'search__vector': search_query}
 
-            queryset = queryset.filter(q)
+            if getattr(view, 'filter_resolve_links', True):
+                subquery = queryset.model.objects.filter(**filter_kwargs).values('root_id').order_by()
+                queryset = queryset.filter(root_id__in=subquery)
+            else:
+                queryset = queryset.filter(**filter_kwargs)
 
         return queryset
 
@@ -123,12 +121,10 @@ class VersionFilterBackend(BaseFilterBackend):
             return queryset
 
         if request.GET.get('all') != 'true':
-            try:
-                # datasets have a public field
-                queryset = queryset.filter(public=True)
-            except FieldError:
-                # files need to check the public field of the corresponding dataset
+            if queryset.model == File:
                 queryset = queryset.filter(dataset__public=True)
+            else:
+                queryset = queryset.filter(public=True)
 
         after = request.GET.get('after')
         if after:
@@ -152,15 +148,13 @@ class IdentifierFilterBackend(BaseFilterBackend):
                 q = Q()
                 for value in request.GET.getlist(identifier):
                     if value:
-                        q |= Q(specifiers__contains={identifier: value})
+                        filter_kwargs = {'specifiers__contains': {identifier: value}}
 
                         if getattr(view, 'filter_resolve_links', True):
-                            q |= Exists(
-                                queryset.model.objects.filter(
-                                    target_id=OuterRef('pk'),
-                                    specifiers__contains={identifier: value}
-                                )
-                            )
+                            subquery = queryset.model.objects.filter(**filter_kwargs).values('root_id').order_by()
+                            q |= Q(root_id__in=subquery)
+                        else:
+                            q |= Q(**filter_kwargs)
 
                 queryset = queryset.filter(q)
 
@@ -178,18 +172,17 @@ class TreeFilterBackend(BaseFilterBackend):
             q = Q()
             for tree in tree_list:
                 tree = tree.rstrip('/') + '/'
+
                 if queryset.model == File:
-                    q |= Q(dataset__tree_path__startswith=tree)
-                    if getattr(view, 'filter_resolve_links', True):
-                        q |= Exists(
-                            queryset.model.objects.filter(target_id=OuterRef('pk'), dataset__tree_path__startswith=tree)
-                        )
+                    filter_kwargs = {'dataset__tree_path__startswith': tree}
                 else:
-                    q |= Q(tree_path__startswith=tree)
-                    if getattr(view, 'filter_resolve_links', True):
-                        q |= Exists(
-                            queryset.model.objects.filter(target_id=OuterRef('pk'), tree_path__startswith=tree)
-                        )
+                    filter_kwargs = {'tree_path__startswith': tree}
+
+                if getattr(view, 'filter_resolve_links', True):
+                    subquery = queryset.model.objects.filter(**filter_kwargs).values('root_id').order_by()
+                    q |= Q(root_id__in=subquery)
+                else:
+                    q |= Q(**filter_kwargs)
 
             queryset = queryset.filter(q)
 

--- a/isimip_data/metadata/managers.py
+++ b/isimip_data/metadata/managers.py
@@ -6,7 +6,12 @@ class DatasetQuerySet(models.QuerySet):
 
     def histogram(self, identifier):
         field = f'specifiers__{identifier}'
-        return self.values_list(field).annotate(count=models.Count(field)).order_by(field)
+        return (
+            self.annotate(distinct_id=models.functions.Coalesce('target_id', 'id'))
+                .values_list(field)
+                .annotate(count=models.Count('distinct_id', distinct=True))
+                .order_by(field)
+        )
 
 
 class DatasetManager(models.Manager):

--- a/isimip_data/metadata/managers.py
+++ b/isimip_data/metadata/managers.py
@@ -1,16 +1,16 @@
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db import models
+from django.db.models.fields.json import KeyTextTransform
 
 
 class DatasetQuerySet(models.QuerySet):
 
     def histogram(self, identifier):
-        field = f'specifiers__{identifier}'
         return (
-            self.annotate(distinct_id=models.functions.Coalesce('target_id', 'id'))
-                .values_list(field)
-                .annotate(count=models.Count('distinct_id', distinct=True))
-                .order_by(field)
+            self.annotate(specifier=KeyTextTransform(identifier, 'specifiers'))
+                .values_list('specifier')
+                .annotate(count=models.Count('root_id', distinct=True))
+                .order_by('specifier')
         )
 
 

--- a/isimip_data/metadata/middleware.py
+++ b/isimip_data/metadata/middleware.py
@@ -1,12 +1,10 @@
 import re
-from datetime import UTC
 
 from django.db.models import Max
 from django.middleware.cache import CacheMiddleware
 from django.utils.cache import learn_cache_key
-from django.utils.timezone import make_aware
 
-from .models import Dataset, Resource
+from .models import Dataset, File, Resource
 
 
 class MetadataCacheMiddleware(CacheMiddleware):
@@ -23,19 +21,19 @@ class MetadataCacheMiddleware(CacheMiddleware):
     )
 
     def process_request(self, request):
-        self.update = self.check_path_info(request.path_info, self.update_patterns)
-        self.path = self.check_path_info(request.path_info, self.path_patterns)
+        request._in_update_patterns = self._check_path_info(request.path_info, self.update_patterns)
+        request._in_path_patterns = self._check_path_info(request.path_info, self.path_patterns)
 
-        if self.update or self.path:
-            self.update_cache()
+        if request._in_update_patterns or request._in_path_patterns:
+            self._check_cache_invalidation()
 
-        if self.path:
+        if request._in_path_patterns:
             return super().process_request(request)
         else:
             return None
 
     def process_response(self, request, response):
-        if self.path:
+        if getattr(request, '_in_path_patterns', False):
             # this is a limited version of process_response in UpdateCacheMiddleware
             # which does not set the headers to let the client cache the response as well
             if not self._should_update_cache(request, response):
@@ -48,31 +46,30 @@ class MetadataCacheMiddleware(CacheMiddleware):
 
         return response
 
-    def check_path_info(self, path_info, patterns):
+    def _check_path_info(self, path_info, patterns):
         return any(pattern.search(path_info) for pattern in patterns)
 
-    def update_cache(self):
+    def _check_cache_invalidation(self):
+        # skip check if we checked recently
+        if self.cache.get('invalidation_checked'):
+            return
+
         # get the cache_timestamp from the cache
         cache_timestamp = self.cache.get('timestamp')
 
         # get the latest timestamp from the datasets and resources table
-        timestamp_values = [
-            make_aware(value, UTC) for value in Dataset.objects.using('metadata').aggregate(
-                Max('created'),
-                Max('updated'),
-                Max('published'),
-                Max('archived')
-            ).values() if value is not None
-        ] + [
-            make_aware(value, UTC) for value in Resource.objects.using('metadata').aggregate(
-                Max('created'),
-                Max('updated')
-            ).values() if value is not None
+        timestamps = [
+            Dataset.objects.using('metadata').aggregate(latest=Max('last_changed'))['latest'],
+            File.objects.using('metadata').aggregate(latest=Max('last_changed'))['latest'],
+            Resource.objects.using('metadata').aggregate(latest=Max('last_changed'))['latest'],
         ]
-        timestamp = max(timestamp_values) if timestamp_values else None
+        timestamp = max(t for t in timestamps if t is not None)
 
         # check if the timestamp is later than cache_timestamp
-        if cache_timestamp is None or timestamp is None or timestamp > cache_timestamp:
+        if cache_timestamp is None or timestamp > cache_timestamp:
             # the datasets table has changed, clear the cache and set a new timestamp
             self.cache.clear()
             self.cache.set('timestamp', timestamp, self.cache_timeout)
+
+        # mark that we just checked, regardless of whether we invalidated
+        self.cache.set('invalidation_checked', True, 30)

--- a/isimip_data/metadata/models.py
+++ b/isimip_data/metadata/models.py
@@ -38,6 +38,8 @@ class Dataset(models.Model):
     published = models.DateTimeField()
     archived = models.DateTimeField()
 
+    root_id = models.UUIDField(editable=False)
+
     class Meta:
         db_table = 'datasets'
         managed = False
@@ -130,6 +132,8 @@ class File(models.Model):
 
     created = models.DateTimeField()
     updated = models.DateTimeField()
+
+    root_id = models.UUIDField(editable=False)
 
     class Meta:
         db_table = 'files'

--- a/isimip_data/metadata/models.py
+++ b/isimip_data/metadata/models.py
@@ -37,6 +37,7 @@ class Dataset(models.Model):
     updated = models.DateTimeField()
     published = models.DateTimeField()
     archived = models.DateTimeField()
+    last_changed = models.DateTimeField()
 
     root_id = models.UUIDField(editable=False)
 
@@ -132,6 +133,7 @@ class File(models.Model):
 
     created = models.DateTimeField()
     updated = models.DateTimeField()
+    last_changed = models.DateTimeField()
 
     root_id = models.UUIDField(editable=False)
 
@@ -235,6 +237,7 @@ class Resource(models.Model):
 
     created = models.DateTimeField()
     updated = models.DateTimeField()
+    last_changed = models.DateTimeField()
 
     datasets = models.ManyToManyField(Dataset, related_name='resources')
 

--- a/isimip_data/metadata/serializers.py
+++ b/isimip_data/metadata/serializers.py
@@ -205,34 +205,37 @@ class DatasetSerializer(serializers.ModelSerializer):
             return reverse('dataset-detail-filelist', args=[obj.id], request=self.context.get('request'))
 
     def get_caveats(self, obj):
-        if self.context.get('request').GET.get('caveats'):
-            user = self.context['request'].user
-            queryset = Caveat.objects.exclude(public=False) \
-                                     .filter(datasets__contains=[obj.id]).public(user)
-            serializer = DatasetCaveatSerializer(queryset, many=True)
-            return serializer.data
-        else:
-            return []
+        caveats = [
+            caveat
+            for caveat in self.context.get('caveats', [])
+            if obj.id in caveat.datasets
+        ]
+        serializer = DatasetCaveatSerializer(caveats, many=True)
+        return serializer.data
 
     def get_caveats_versions(self, obj):
-        if self.context.get('request').GET.get('caveats'):
-            user = self.context['request'].user
-            versions = Dataset.objects.using('metadata').filter(path=obj.path).exclude(id=obj.id)
-            queryset = Caveat.objects.exclude(public=False) \
-                                     .exclude(datasets__contains=[obj.id]) \
-                                     .filter(datasets__overlap=[version.id for version in versions]).public(user)
-            serializer = DatasetCaveatSerializer(queryset, many=True)
-            return serializer.data
-        else:
-            return []
+        versions = [
+            version
+            for version in self.context.get('versions', [])
+            if obj.path in version.path
+        ]
+        caveats = [
+            caveat
+            for caveat in self.context.get('caveats_versions', [])
+            for version in versions
+            if version.id in caveat.datasets
+        ]
+        serializer = DatasetCaveatSerializer(caveats, many=True)
+        return serializer.data
 
     def get_annotations(self, obj):
-        if self.context.get('request').GET.get('annotations'):
-            queryset = Annotation.objects.filter(datasets__contains=[obj.id])
-            serializer = DatasetAnnotationSerializer(queryset, many=True)
-            return serializer.data
-        else:
-            return []
+        annotations = [
+            annotation
+            for annotation in self.context.get('annotations', [])
+            if obj.id in annotation.datasets
+        ]
+        serializer = DatasetAnnotationSerializer(annotations, many=True)
+        return serializer.data
 
 
 class FileLinkSerializer(serializers.ModelSerializer):

--- a/isimip_data/metadata/serializers.py
+++ b/isimip_data/metadata/serializers.py
@@ -214,16 +214,10 @@ class DatasetSerializer(serializers.ModelSerializer):
         return serializer.data
 
     def get_caveats_versions(self, obj):
-        versions = [
-            version
-            for version in self.context.get('versions', [])
-            if obj.path in version.path
-        ]
         caveats = [
             caveat
             for caveat in self.context.get('caveats_versions', [])
-            for version in versions
-            if version.id in caveat.datasets
+            if self.context.get('versions', {}).get(obj.path).intersection(caveat.datasets)
         ]
         serializer = DatasetCaveatSerializer(caveats, many=True)
         return serializer.data

--- a/isimip_data/metadata/sitemaps.py
+++ b/isimip_data/metadata/sitemaps.py
@@ -1,64 +1,36 @@
 from django.contrib.sitemaps import Sitemap
-from django.db.models.functions import Greatest
 
 from .models import Dataset, File, Resource
 
 
 class DatasetSitemap(Sitemap):
     changefreq = 'never'
-    limit = 50_000
+    limit = 10_000
 
     def items(self):
-        return (
-            Dataset.objects
-            .using('metadata')
-            .order_by('id')
-            .annotate(last_changed=Greatest('created', 'updated', 'published', 'archived'))
-            .values('id', 'last_changed')
-        )
+        return Dataset.objects.using('metadata').order_by('id').only('id', 'last_changed')
 
     def lastmod(self, obj):
-        return obj['last_changed']
-
-    def location(self, obj):
-        return f'/datasets/{obj["id"]}/'
+        return obj.last_changed
 
 
 class FileSitemap(Sitemap):
     changefreq = 'never'
-    limit = 50_000
+    limit = 10_000
 
     def items(self):
-        return (
-            File.objects
-            .using('metadata')
-            .order_by('id')
-            .annotate(last_changed=Greatest('created', 'updated'))
-            .values('id', 'last_changed')
-        )
+        return File.objects.using('metadata').order_by('id').only('id', 'last_changed')
 
     def lastmod(self, obj):
-        return obj['last_changed']
-
-    def location(self, obj):
-        return f'/files/{obj["id"]}/'
+        return obj.last_changed
 
 
 class ResourceSitemap(Sitemap):
     changefreq = 'never'
-    limit = 50_000
+    limit = 10_000
 
     def items(self):
-        return (
-            Resource.objects
-            .using('metadata')
-            .order_by('id')
-            .annotate(last_changed=Greatest('created', 'updated'))
-            .values('id', 'doi', 'last_changed')
-        )
+        return Resource.objects.using('metadata').order_by('id').only('id', 'last_changed')
 
     def lastmod(self, obj):
-        return obj['last_changed']
-
-    def location(self, obj):
-        return f'/{obj["doi"]}/'
+        return obj.last_changed

--- a/isimip_data/metadata/viewsets.py
+++ b/isimip_data/metadata/viewsets.py
@@ -14,6 +14,9 @@ from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet, ViewSet
 
+from isimip_data.annotations.models import Annotation
+from isimip_data.caveats.models import Caveat
+
 from .filters import (
     ChecksumFilterBackend,
     DatasetFilterBackend,
@@ -80,6 +83,43 @@ class DatasetViewSet(ReadOnlyModelViewSet):
         IdentifierFilterBackend,
         TreeFilterBackend
     )
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+
+        if (
+            self.action == 'list' and
+            self.paginator is not None and
+            self.paginator.page is not None and
+            self.paginator.page.object_list
+        ):
+            dataset_ids = [obj.id for obj in self.paginator.page.object_list]
+            dataset_paths = [obj.path for obj in self.paginator.page.object_list]
+
+            if self.request.GET.get('caveats'):
+                context['versions'] = (
+                    Dataset.objects.using('metadata')
+                    .filter(path__in=dataset_paths)
+                    .exclude(id__in=dataset_ids)
+                )
+                context['caveats'] = (
+                    Caveat.objects
+                    .filter(datasets__overlap=dataset_ids)
+                    .exclude(public=False)
+                    .public(self.request.user)
+                )
+                context['caveats_versions'] = (
+                    Caveat.objects
+                    .filter(datasets__overlap=[version.id for version in context['versions']])
+                    .exclude(public=False)
+                    .exclude(id__in=[caveat.id for caveat in context['caveats']])
+                    .public(self.request.user)
+                )
+
+            if self.request.GET.get('annotations'):
+                context['annotations'] = Annotation.objects.filter(datasets__overlap=dataset_ids)
+
+        return context
 
     @action(detail=False)
     def suggestions(self, request):

--- a/isimip_data/metadata/viewsets.py
+++ b/isimip_data/metadata/viewsets.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from itertools import product
 from pathlib import PurePath
 
@@ -97,20 +98,27 @@ class DatasetViewSet(ReadOnlyModelViewSet):
             dataset_paths = [obj.path for obj in self.paginator.page.object_list]
 
             if self.request.GET.get('caveats'):
-                context['versions'] = (
+                versions = list(
                     Dataset.objects.using('metadata')
                     .filter(path__in=dataset_paths)
                     .exclude(id__in=dataset_ids)
+                    .only('id', 'path')
                 )
-                context['caveats'] = (
+
+                context['versions'] = defaultdict(set)
+                for version in versions:
+                    context['versions'][version.path].add(version.id)
+
+                context['caveats'] = list(
                     Caveat.objects
                     .filter(datasets__overlap=dataset_ids)
                     .exclude(public=False)
                     .public(self.request.user)
                 )
-                context['caveats_versions'] = (
+
+                context['caveats_versions'] = list(
                     Caveat.objects
-                    .filter(datasets__overlap=[version.id for version in context['versions']])
+                    .filter(datasets__overlap=[version.id for version in versions])
                     .exclude(public=False)
                     .exclude(id__in=[caveat.id for caveat in context['caveats']])
                     .public(self.request.user)

--- a/isimip_data/metadata/viewsets.py
+++ b/isimip_data/metadata/viewsets.py
@@ -46,7 +46,7 @@ class Paginator(DjangoPaginator):
 
     @cached_property
     def count(self):
-        return self.object_list[:settings.METADATA_MAX_COUNT + 1].count()
+        return self.object_list.order_by()[:settings.METADATA_MAX_COUNT + 1].count()
 
 
 class Pagination(PageNumberPagination):
@@ -59,13 +59,16 @@ class Pagination(PageNumberPagination):
 
 class DatasetViewSet(ReadOnlyModelViewSet):
 
+    queryset = (
+        Dataset.objects.using('metadata').filter(target=None).prefetch_related(
+            'files',
+            'files__links',
+            'links',
+            'resources'
+        )
+    )
+
     serializer_class = DatasetSerializer
-    queryset = Dataset.objects.using('metadata').filter(target=None).prefetch_related(
-        'files',
-        'files__links',
-        'links',
-        'resources'
-    ).distinct('path', 'version')
     pagination_class = Pagination
 
     filter_backends = (
@@ -148,9 +151,11 @@ class DatasetViewSet(ReadOnlyModelViewSet):
 
 class FileViewSet(ReadOnlyModelViewSet):
 
+    queryset = (
+        File.objects.using('metadata').filter(target=None).select_related('dataset').prefetch_related('links')
+    )
+
     serializer_class = FileSerializer
-    queryset = File.objects.using('metadata').filter(target=None).select_related('dataset') \
-                           .prefetch_related('links').distinct('path', 'version')
     pagination_class = Pagination
 
     filter_backends = (
@@ -168,8 +173,8 @@ class FileViewSet(ReadOnlyModelViewSet):
 
 class ResourceViewSet(ReadOnlyModelViewSet):
 
-    serializer_class = ResourceSerializer
     queryset = Resource.objects.using('metadata')
+    serializer_class = ResourceSerializer
     pagination_class = Pagination
 
     filter_backends = (
@@ -302,8 +307,8 @@ class TreeViewSet(ViewSet):
 
 class IdentifierViewSet(ReadOnlyModelViewSet):
 
-    serializer_class = IdentifierSerializer
     queryset = Identifier.objects.using('metadata')
+    serializer_class = IdentifierSerializer
 
 
 class GlossaryViewSet(ViewSet):

--- a/isimip_data/metadata/viewsets.py
+++ b/isimip_data/metadata/viewsets.py
@@ -77,7 +77,6 @@ class DatasetViewSet(ReadOnlyModelViewSet):
         IdentifierFilterBackend,
         TreeFilterBackend
     )
-    identifier_filter_exclude = None
 
     @action(detail=False)
     def suggestions(self, request):
@@ -106,9 +105,11 @@ class DatasetViewSet(ReadOnlyModelViewSet):
     @action(detail=False, url_path='histogram/(?P<identifier>[A-Za-z0-9_]+)')
     def histogram(self, request, identifier):
         if Identifier.objects.using('metadata').filter(identifier=identifier).exists():
-            # exclude the identifier from IdentifierFilterBackend
-            self.identifier_filter_exclude = identifier
-            queryset = self.filter_queryset(Dataset.objects.using('metadata').filter(target=None))
+            # exclude the identifier from IdentifierFilterBackend and do not resolve links
+            self.filter_exclude_identifier = identifier
+            self.filter_resolve_links = False
+
+            queryset = self.filter_queryset(Dataset.objects.using('metadata'))
             values = queryset.histogram(identifier)
             return Response(values)
         else:


### PR DESCRIPTION
This PR improves the API in several ways:

* Links are included in the `histogram` action and the `queryset` is simplified. This should improve performance with facets in the interface.
* Ordering is removed from the count query.
* The `tree_path` parameter ensures a trailing slash. This need a migration for the metadata database to add this slash in the `tree_path` field.
* The `datasets` and `files` tables now contain an automated `root_id` column which is either `target_id` or `id`.
* Annotations and caveats are now (manually) prefetched in `DatasetViewSet`,
